### PR TITLE
Remove tracking domain

### DIFF
--- a/Sources/Q42Stats/PrivacyInfo.xcprivacy
+++ b/Sources/Q42Stats/PrivacyInfo.xcprivacy
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>q42stats.ew.r.appspot.com</string>
-	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 	<key>NSPrivacyCollectedDataTypes</key>


### PR DESCRIPTION
We can remove this, since it doesn't fall under Apple's definition of tracking:

> Tracking refers to the act of linking user or device data collected from your app with user or device data collected from other companies’ apps, websites, or offline properties for targeted advertising or advertising measurement purposes. Tracking also refers to sharing user or device data with data brokers.

Since this data is for research purposes and not related to advertising or tracking the user, we can remove the domain.