### PR TITLE
Don't log UI style if the app is always in light mode or always in dark mode

### DIFF
--- a/Sources/Q42Stats/Q42Stats.swift
+++ b/Sources/Q42Stats/Q42Stats.swift
@@ -188,9 +188,13 @@ public class Q42Stats: NSObject {
 
         if options.contains(.preferences) {
             if #available(iOS 13.0, *) {
+              let overrideInterfaceStyle = Bundle.main.object(forInfoDictionaryKey: "UIUserInterfaceStyle") as? String
+              // Don't log UI style if the app is always in light mode or always in dark mode.
+              if overrideInterfaceStyle != "Dark" && overrideInterfaceStyle != "Light" {
                 let style = UITraitCollection.current.userInterfaceStyle
                 _log(key: "Preference_UI_style", value: style.description)
                 _log(key: "Preference_daytime", value: dayNight())
+              }
 
                 let category = UITraitCollection.current.preferredContentSizeCategory
                 _log(key: "Preference_preferred_content_size", value: category.description)


### PR DESCRIPTION
It is possible to put an app permanently into light mode (or dark mode) using the Info.plist key `UIUserInterfaceStyle`. If this is set to either of these values, the user's dark mode preference has no effect and the app will report the override interface style. In this case, don't include it in the statistics.