### PR TITLE
Support Swift 6 language mode 

### DIFF
--- a/Q42Stats-Demo.xcodeproj/project.pbxproj
+++ b/Q42Stats-Demo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -55,9 +55,9 @@
 				E250308D23F444210053A644 /* Q42Stats-Demo */,
 				E250308C23F444210053A644 /* Products */,
 			);
-			indentWidth = 2;
+			indentWidth = 4;
 			sourceTree = "<group>";
-			tabWidth = 2;
+			tabWidth = 4;
 		};
 		E250308C23F444210053A644 /* Products */ = {
 			isa = PBXGroup;
@@ -102,8 +102,9 @@
 		E250308323F444210053A644 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1030;
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 1620;
 				ORGANIZATIONNAME = Q42;
 				TargetAttributes = {
 					E250308A23F444210053A644 = {
@@ -113,7 +114,6 @@
 				};
 			};
 			buildConfigurationList = E250308623F444210053A644 /* Build configuration list for PBXProject "Q42Stats-Demo" */;
-			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -121,6 +121,7 @@
 				Base,
 			);
 			mainGroup = E250308223F444210053A644;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = E250308C23F444210053A644 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -158,6 +159,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -192,6 +194,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -206,7 +209,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -220,6 +222,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -254,6 +257,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -262,7 +266,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -278,8 +281,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = LC3Y92HQQ3;
+				DEVELOPMENT_TEAM = 8J6VSUTQNX;
 				INFOPLIST_FILE = "Q42Stats-Demo.xcodeproj/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -287,7 +291,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "nl.q42.Q42Stats-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -298,15 +302,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = LC3Y92HQQ3;
+				DEVELOPMENT_TEAM = 8J6VSUTQNX;
 				INFOPLIST_FILE = "Q42Stats-Demo.xcodeproj/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "nl.q42.Q42Stats-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Q42Stats-Demo/AppDelegate.swift
+++ b/Q42Stats-Demo/AppDelegate.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 

--- a/Sources/Q42Stats/Q42Stats.swift
+++ b/Sources/Q42Stats/Q42Stats.swift
@@ -124,6 +124,7 @@ public class Q42Stats: NSObject {
         }
     }
 
+    @MainActor
     private func _log(key: String, value: String) {
         collected[key] = value
     }
@@ -270,7 +271,10 @@ public class Q42Stats: NSObject {
 extension Q42Stats: WCSessionDelegate {
     @available(iOS 9.3, *)
     public func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        self._log(key: "Watch_paired", value: session.isPaired.description)
+        let watchPairedValue = session.isPaired.description
+        DispatchQueue.main.async {
+            self._log(key: "Watch_paired", value: watchPairedValue)
+        }
     }
 
     public func sessionDidBecomeInactive(_ session: WCSession) {}

--- a/Sources/Q42Stats/Q42Stats.swift
+++ b/Sources/Q42Stats/Q42Stats.swift
@@ -13,7 +13,7 @@ import WatchConnectivity
 /// Collect stats for Q42 internal usage, shared accross multiple iOS projects.
 ///
 public class Q42Stats: NSObject {
-    public struct Configuration {
+    public struct Configuration: Sendable {
         let apiKey: String
         let firestoreCollection: String
         let minimumSubmitInterval: TimeInterval
@@ -27,7 +27,7 @@ public class Q42Stats: NSObject {
         }
     }
 
-    public struct StatsOptions: OptionSet {
+    public struct StatsOptions: OptionSet, Sendable {
         public let rawValue: Int
         public init(rawValue: Int) { self.rawValue = rawValue }
 
@@ -44,7 +44,6 @@ public class Q42Stats: NSObject {
         ]
     }
 
-    private static var shared: Q42Stats?
     private static let statsVersion = "iOS 2022-04-15"
 
     private static let collectedStatsKey = "nl.q42.stats.collectedStatsKey"
@@ -58,8 +57,6 @@ public class Q42Stats: NSObject {
         self.options = options
 
         super.init()
-
-        Q42Stats.shared = self
     }
 
     private static func seedPreviousSubmitMomentIfNeeded(minimumSubmitInterval: TimeInterval) {
@@ -134,7 +131,8 @@ public class Q42Stats: NSObject {
     /// Start collection of statistics.
     ///
     /// - Note: Must be called from the main queue
-    public func collect(window: UIWindow?, completion: @escaping ([String: String]) -> Void) {
+  @MainActor
+  public func collect(window: UIWindow?, completion: @escaping ([String: String]) -> Void) {
         collected = [:]
 
         _log(key: "Stats_version", value: Q42Stats.statsVersion)
@@ -272,9 +270,7 @@ public class Q42Stats: NSObject {
 extension Q42Stats: WCSessionDelegate {
     @available(iOS 9.3, *)
     public func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        DispatchQueue.main.async {
-            self._log(key: "Watch_paired", value: session.isPaired.description)
-        }
+        self._log(key: "Watch_paired", value: session.isPaired.description)
     }
 
     public func sessionDidBecomeInactive(_ session: WCSession) {}
@@ -405,6 +401,7 @@ private extension UILegibilityWeight {
 }
 
 private extension UIAccessibility {
+    @MainActor
     static func usesAnyAccessibilitySetting() -> Bool {
         var enabled = false
 

--- a/Tests/Q42StatsTests/Q42StatsTests.swift
+++ b/Tests/Q42StatsTests/Q42StatsTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Q42Stats
 
 final class Q42StatsTests: XCTestCase {
-    func testCollectAccessibilityStatistics() throws {
+    @MainActor func testCollectAccessibilityStatistics() throws {
         let stats = Q42Stats(options: [.accessibility])
         let expectation = expectation(description: "Stats collection")
         stats.collect(window: nil) { result in


### PR DESCRIPTION
## In this PR:

[Support Swift 6 language mode](https://github.com/Q42/Q42Stats/commit/73d39a37cc285fb4e32b68aad1f9e9aa7139bb39) 

* Make models conform to Sendable
* Remove private static 'shared' property because it was not used
* Mark collection methods as @mainactor

[Update Demo app to modern settings](https://github.com/Q42/Q42Stats/commit/b446087b1a0f73fcea1b7b0e28e2d54bed465d14) 

* Update to modern Xcode project settings
* Enable Swift 6.0 language mode